### PR TITLE
Add support for 'date' and 'time' formats in type resolution

### DIFF
--- a/src/json_schema_to_pydantic/builders.py
+++ b/src/json_schema_to_pydantic/builders.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime, time
 from typing import Any, Dict, Literal
 from uuid import UUID
 
@@ -34,6 +34,10 @@ class ConstraintBuilder(IConstraintBuilder):
                 return constraints
             elif format_type == "date-time":
                 return datetime
+            elif format_type == "date":
+                return date
+            elif format_type == "time":
+                return time
             elif format_type == "uri":
                 return AnyUrl
             elif format_type == "uuid":

--- a/src/json_schema_to_pydantic/resolvers.py
+++ b/src/json_schema_to_pydantic/resolvers.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime, time
 from typing import Any, List, Literal, Optional, Set
 from uuid import UUID
 
@@ -92,6 +92,8 @@ class TypeResolver(ITypeResolver):
             format_type = schema["format"]
             format_map = {
                 "date-time": datetime,
+                "date": date,
+                "time": time,
                 "email": str,
                 "uri": AnyUrl,
                 "uuid": UUID,

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -147,7 +147,7 @@ def test_type_resolver_complex_types():
 def test_type_resolver_format_handling():
     """Test handling of format specifications."""
     resolver = TypeResolver()
-    from datetime import datetime
+    from datetime import datetime, date, time
     from uuid import UUID
 
     from pydantic import AnyUrl
@@ -155,6 +155,8 @@ def test_type_resolver_format_handling():
     assert (
         resolver.resolve_type({"type": "string", "format": "date-time"}, {}) == datetime
     )
+    assert resolver.resolve_type({"type": "string", "format": "date"}, {}) == date
+    assert resolver.resolve_type({"type": "string", "format": "time"}, {}) == time
     assert resolver.resolve_type({"type": "string", "format": "email"}, {}) is str
     assert resolver.resolve_type({"type": "string", "format": "uri"}, {}) == AnyUrl
     assert resolver.resolve_type({"type": "string", "format": "uuid"}, {}) == UUID


### PR DESCRIPTION
Added support for 'date' and 'time' resolutions in builders, resolvers, test_resolvers.