### PR TITLE
Add support for array types in PydanticModelBuilder with recursive object model creation

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -220,10 +220,10 @@ def test_complex_schema_with_undefined_arrays():
     assert instance.tags == ["important", "urgent"]
     assert instance.metadata.categories == ["A", "B", "C"]
     assert instance.metadata.flags == [True, False, True]
-    # Access history items as dictionaries since they might not be converted to models
-    assert instance.history[0]["timestamp"] == "2023-01-01"
-    assert instance.history[0]["actions"] == ["created", "modified"]
-    assert instance.history[1]["actions"] == ["reviewed", 123, {"status": "approved"}]
+    # Access history items as Pydantic models
+    assert instance.history[0].timestamp == "2023-01-01"
+    assert instance.history[0].actions == ["created", "modified"]
+    assert instance.history[1].actions == ["reviewed", 123, {"status": "approved"}]
 
 
 def test_root_level_features():

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -311,9 +311,9 @@ def test_type_resolver_nested_array_references():
 
     model = create_model(root_schema)
     instance = model.model_validate({"a": [{"b": 1}, {"b": 2}]})
-    # Access as dictionary items since they're dictionaries, not models
-    assert instance.a[0]["b"] == 1
-    assert instance.a[1]["b"] == 2
+    # Access as Pydantic models
+    assert instance.a[0].b == 1
+    assert instance.a[1].b == 2
 
 
 def test_type_resolver_complex_nested_references():
@@ -387,14 +387,14 @@ def test_type_resolver_complex_nested_references():
     )
 
     # Verify the structure was correctly parsed
-    # Access as dictionary items since they're dictionaries, not models
-    assert instance.items[0]["id"] == "item1"
-    assert instance.items[0]["nested_items"][0]["name"] == "nested1"
-    assert instance.items[0]["nested_items"][0]["value"] == 10
-    assert instance.items[0]["metadata"]["key1"] == "value1"
-    assert instance.items[1]["id"] == "item2"
-    assert instance.items[1]["nested_items"][0]["name"] == "nested3"
-    assert instance.items[1]["nested_items"][0]["value"] == 30
+    # Access as Pydantic models (our fix now creates proper models)
+    assert instance.items[0].id == "item1"
+    assert instance.items[0].nested_items[0].name == "nested1"
+    assert instance.items[0].nested_items[0].value == 10
+    assert instance.items[0].metadata["key1"] == "value1"  # metadata is still dict due to additionalProperties
+    assert instance.items[1].id == "item2"
+    assert instance.items[1].nested_items[0].name == "nested3"
+    assert instance.items[1].nested_items[0].value == 30
     assert instance.description == "A complex nested structure"
 
 


### PR DESCRIPTION
## PR Description

### Overview
This PR enhances the `PydanticModelBuilder` to properly handle array types by implementing recursive processing of array items, ensuring that nested object schemas within arrays are correctly resolved into proper Pydantic models rather than plain dictionaries.

### Key Changes

#### Model Builder Enhancements
- **Array Type Support**: Added comprehensive handling for `"type": "array"` schemas in `PydanticModelBuilder._get_field_type()`
- **Recursive Item Processing**: Array items are now recursively processed through the model builder, ensuring nested objects get proper Pydantic models
- **Unique Items Support**: Arrays with `"uniqueItems": true` are typed as `Set[T]` instead of `List[T]`
- **Undefined Items Handling**: Maintains existing behavior for arrays without defined item schemas

#### Type Resolution Improvements
- Nested object schemas within arrays now generate proper Pydantic model classes
- Improved type safety and IDE support for accessing nested array elements
- Consistent behavior between top-level objects and objects nested within arrays

#### Test Updates
- Refactored tests to access model attributes directly (e.g., `instance.items[0].id`) instead of dictionary-style access
- Added comprehensive test coverage for complex nested array scenarios
- Verified proper model creation for multi-level nested structures

### Example Impact

**Before**: Array items containing objects would be typed as `List[dict]`
```python
# Accessing nested properties required dict-style access
item_id = instance.items[0]["id"]  # Dictionary access
```

**After**: Array items containing objects are now properly typed as `List[ModelClass]`
```python
# Now supports proper model attribute access with IDE support
item_id = instance.items[0].id  # Direct attribute access on Pydantic model
```

### Breaking Changes
- Test assertions that relied on dictionary-style access to nested objects within arrays will need to be updated to use direct attribute access