### PR TITLE
Add support for optional array

### DIFF
--- a/src/json_schema_to_pydantic/resolvers.py
+++ b/src/json_schema_to_pydantic/resolvers.py
@@ -39,7 +39,7 @@ class TypeResolver(ITypeResolver):
                 if len(other_types) == 1:
                     return Optional[
                         self.resolve_type(
-                            schema={"type": other_types[0]},
+                            schema={**schema, **{"type": other_types[0]}},
                             root_schema=root_schema,
                             allow_undefined_array_items=allow_undefined_array_items,
                         )

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -27,6 +27,15 @@ def test_type_resolver_array():
 
     assert resolver.resolve_type(schema, {}) == List[str]
 
+def test_type_resolver_optional_array():
+    resolver = TypeResolver()
+
+    schema = {"type": ["array", "null"], "items": {"type": "string"}}
+    from typing import List, Optional
+
+    print(resolver.resolve_type(schema, {}))
+    assert resolver.resolve_type(schema, {}) == Optional[List[str]]
+
 
 def test_type_resolver_undefined_array_items():
     """Test handling of arrays without defined item types."""

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -33,7 +33,6 @@ def test_type_resolver_optional_array():
     schema = {"type": ["array", "null"], "items": {"type": "string"}}
     from typing import List, Optional
 
-    print(resolver.resolve_type(schema, {}))
     assert resolver.resolve_type(schema, {}) == Optional[List[str]]
 
 


### PR DESCRIPTION
Current behaviour:
- When an optional array is encountered, it is wrapped in `Optional` and only the `type` field from the original schema is passed down, hence losing the `items` field and resulting in `TypeError("Array type must specify 'items' schema")`
Updated behaviour:
- When an optional array is encountered, wrap the whole field in `Optional` and pass the entire field definition, but overriding the type to `array`, preserving the `items` field and resulting in proper schema parsing